### PR TITLE
Create AION 1070 config

### DIFF
--- a/MiningStore Config Files/AION 1070 config
+++ b/MiningStore Config Files/AION 1070 config
@@ -1,0 +1,16 @@
+globalminer ewbf-equihash
+maxgputemp 97
+stratumproxy enabled
+#proxywallet 0xa0c054b0f404406edac24208a8579f387012519ca331c5bd7fcb00fe63479358
+proxywallet 0xa031949a9a11d739f82385778cd01395839b362d8f19ec060dc188f515d27201
+proxypool1 aion-us.luxor.tech:3366
+#proxypool2 aion-eu.luxor.tech:3366
+globalcore +100
+globalmem +400 
+globalfan 90
+globalname disabled
+globalpowertune 110
+autoreboot true
+globaldriver amdgpu
+ewbf-equihash=flags --algo aion
+custompanel msaion123456


### PR DESCRIPTION
Hey y'all, I made a config file for the 1070Ti / 1070 rigs (they run the same overclock settings), so that we can have all of our RFS rigs on a remote config (the two 1070T i/ 1070 rigs are currently running a local config because we don't have a remote config made for it specifically).